### PR TITLE
create multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-# syntax=docker/dockerfile:1
-
-FROM golang:1.17-alpine
+FROM golang:1.17-alpine as BuildStage
 
 WORKDIR /app
 
-COPY go.mod ./
-COPY go.sum ./
+COPY . .
 RUN go mod download
 
-COPY . .
-
 RUN go build -o /plattentests-go
+
+FROM alpine:latest
+
+WORKDIR /
+
+COPY --from=BuildStage /plattentests-go .
 
 EXPOSE 8080
 


### PR DESCRIPTION
reduces resulting docker image from 900mb to 20mb