### PR TITLE
add permissions for workflows

### DIFF
--- a/.github/workflows/deploy-aca.yml
+++ b/.github/workflows/deploy-aca.yml
@@ -56,7 +56,7 @@ jobs:
     
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v1
         with:
           client-id: ${{ secrets.PLATTENTESTS_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.PLATTENTESTS_AZURE_TENANT_ID }}

--- a/.github/workflows/deploy-aca.yml
+++ b/.github/workflows/deploy-aca.yml
@@ -12,7 +12,14 @@ on:
     branches: 
       [ main ]
   # Allow mannually trigger 
-  workflow_dispatch:      
+  workflow_dispatch:   
+
+
+permissions:
+  id-token: write #This is required for requesting the OIDC JWT Token
+  contents: read #Required when GH token is used to authenticate with private repo
+
+   
 
 jobs:
   build:
@@ -45,9 +52,6 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    permissions: 
-      id-token: write #This is required for requesting the OIDC JWT Token
-      contents: read #Required when GH token is used to authenticate with private repo
     needs: build
     
     steps:

--- a/.github/workflows/deploy-aca.yml
+++ b/.github/workflows/deploy-aca.yml
@@ -45,6 +45,9 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions: 
+      id-token: write #This is required for requesting the OIDC JWT Token
+      contents: read #Required when GH token is used to authenticate with private repo
     needs: build
     
     steps:

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -37,6 +37,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    permissions: 
+      id-token: write #This is required for requesting the OIDC JWT Token
+      contents: read #Required when GH token is used to authenticate with private repo
     steps:
     - uses: actions/checkout@v4
     - name: Download


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow files to enhance security and permissions for deployment jobs. The most important changes are:

Permissions updates in workflow files:

* [`.github/workflows/deploy-aca.yml`](diffhunk://#diff-5a9900fa1a5759950da1105b6fb2707cde33161ac213d65ef067c3a6c0d5f1deR48-R50): Added `id-token: write` and `contents: read` permissions to the `deploy` job to enable OIDC JWT Token requests and authentication with private repositories.
* [`.github/workflows/deploy-functions.yml`](diffhunk://#diff-ac55ceba65206b39da07765237ce475d5be4c2106f88c98dfcd8b503f0f28101R40-R42): Added `id-token: write` and `contents: read` permissions to the `deploy` job to enable OIDC JWT Token requests and authentication with private repositories.